### PR TITLE
It should put into triggered FIFO if it was not present

### DIFF
--- a/icelib/src/fifo.c
+++ b/icelib/src/fifo.c
@@ -204,7 +204,7 @@ bool ICELIB_triggeredFifoPutIfNotPresent(ICELIB_TRIGGERED_FIFO *fifo,
                                          ICELIB_LIST_PAIR      *pair,
                                          ICELIB_CALLBACK_LOG   *callbackLog)
 {
-    if (ICELIB_isTriggeredFifoPairPresent(fifo, pair, callbackLog)) {
+    if (!ICELIB_isTriggeredFifoPairPresent(fifo, pair, callbackLog)) {
         return ICELIB_fifoPut(fifo, pair->pairId);
     }
     return false;


### PR DESCRIPTION
If it was already in the FIFO, we need not to put it again, rather it should put into FIFO if it was not present.
